### PR TITLE
Ajout champ "role" sur entité "User"

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -12,6 +12,7 @@ doctrine:
             resourceCategoryType: App\Doctrine\DBAL\Types\ResourceCategoryType
             resourceSharedStatusType: App\Doctrine\DBAL\Types\ResourceSharedStatusType
             resourceTypeType: App\Doctrine\DBAL\Types\ResourceTypeType
+            userRoleType: App\Doctrine\DBAL\Types\UserRoleType
 
     orm:
         auto_generate_proxy_classes: true

--- a/dump/ressources.sql
+++ b/dump/ressources.sql
@@ -184,11 +184,20 @@ ALTER TABLE public.resource_relation_type OWNER TO pedro;
 CREATE TABLE public."user" (
     id integer NOT NULL,
     username character varying(255) NOT NULL,
-    account_enabled boolean DEFAULT true NOT NULL
+    account_enabled boolean DEFAULT true NOT NULL,
+    role character varying(255) DEFAULT 'citoyen connecté'::character varying NOT NULL,
+    CONSTRAINT user_role_check CHECK (((role)::text = ANY ((ARRAY['citoyen connecté'::character varying, 'modérateur'::character varying, 'administrateur'::character varying, 'super administrateur'::character varying])::text[])))
 );
 
 
 ALTER TABLE public."user" OWNER TO pedro;
+
+--
+-- Name: COLUMN "user".role; Type: COMMENT; Schema: public; Owner: pedro
+--
+
+COMMENT ON COLUMN public."user".role IS '(DC2Type:userRoleType)';
+
 
 --
 -- Name: user_data; Type: TABLE; Schema: public; Owner: pedro
@@ -237,8 +246,9 @@ ALTER TABLE public.user_id_seq OWNER TO pedro;
 --
 
 COPY public.doctrine_migration_versions (version, executed_at, execution_time) FROM stdin;
-DoctrineMigrations\\Version20240208222614	2024-03-11 15:12:52	14
-DoctrineMigrations\\Version20240311140314	2024-03-11 15:12:52	25
+DoctrineMigrations\\Version20240208222614	2024-03-13 15:02:06	16
+DoctrineMigrations\\Version20240311140314	2024-03-13 15:02:06	29
+DoctrineMigrations\\Version20240313142256	2024-03-13 15:02:06	3
 \.
 
 
@@ -267,7 +277,7 @@ COPY public.relation_type (id, parent_id, type) FROM stdin;
 --
 
 COPY public.resource (id, user_data_id, file_name, shared_status, category, type, creation_date, modification_date) FROM stdin;
-1	3	Extrait - La Boétie.pdf	public	recherche_de_sens	cours_pdf	2024-03-11 15:12:53	2024-03-11 15:12:53
+1	3	Extrait - La Boétie.pdf	public	recherche_de_sens	cours_pdf	2024-03-13 15:02:08	2024-03-13 15:02:08
 \.
 
 
@@ -276,7 +286,7 @@ COPY public.resource (id, user_data_id, file_name, shared_status, category, type
 --
 
 COPY public.resource_metadata (id, resource_id, title, duration, format, author, album, genre, release_date, creation_date, modification_date) FROM stdin;
-1	1	Discours de la servitude volontaire	\N	\N	Etienne de La Boétie	\N	\N	\N	2024-03-11 15:12:53	2024-03-11 15:12:53
+1	1	Discours de la servitude volontaire	\N	\N	Etienne de La Boétie	\N	\N	\N	2024-03-13 15:02:08	2024-03-13 15:02:08
 \.
 
 
@@ -293,10 +303,10 @@ COPY public.resource_relation_type (resource_id, relation_type_id) FROM stdin;
 -- Data for Name: user; Type: TABLE DATA; Schema: public; Owner: pedro
 --
 
-COPY public."user" (id, username, account_enabled) FROM stdin;
-1	Pedro	t
-2	Maria	t
-3	UserForDeleteTest	t
+COPY public."user" (id, username, account_enabled, role) FROM stdin;
+1	Pedro	t	citoyen connecté
+2	Maria	t	citoyen connecté
+3	UserForDeleteTest	t	citoyen connecté
 \.
 
 

--- a/dump/ressources_test.sql
+++ b/dump/ressources_test.sql
@@ -184,11 +184,20 @@ ALTER TABLE public.resource_relation_type OWNER TO pedro;
 CREATE TABLE public."user" (
     id integer NOT NULL,
     username character varying(255) NOT NULL,
-    account_enabled boolean DEFAULT true NOT NULL
+    account_enabled boolean DEFAULT true NOT NULL,
+    role character varying(255) DEFAULT 'citoyen connecté'::character varying NOT NULL,
+    CONSTRAINT user_role_check CHECK (((role)::text = ANY ((ARRAY['citoyen connecté'::character varying, 'modérateur'::character varying, 'administrateur'::character varying, 'super administrateur'::character varying])::text[])))
 );
 
 
 ALTER TABLE public."user" OWNER TO pedro;
+
+--
+-- Name: COLUMN "user".role; Type: COMMENT; Schema: public; Owner: pedro
+--
+
+COMMENT ON COLUMN public."user".role IS '(DC2Type:userRoleType)';
+
 
 --
 -- Name: user_data; Type: TABLE; Schema: public; Owner: pedro
@@ -237,8 +246,9 @@ ALTER TABLE public.user_id_seq OWNER TO pedro;
 --
 
 COPY public.doctrine_migration_versions (version, executed_at, execution_time) FROM stdin;
-DoctrineMigrations\\Version20240208222614	2024-03-11 15:13:02	16
-DoctrineMigrations\\Version20240311140314	2024-03-11 15:13:02	29
+DoctrineMigrations\\Version20240208222614	2024-03-13 15:06:05	16
+DoctrineMigrations\\Version20240311140314	2024-03-13 15:06:05	27
+DoctrineMigrations\\Version20240313142256	2024-03-13 15:06:05	3
 \.
 
 
@@ -267,7 +277,7 @@ COPY public.relation_type (id, parent_id, type) FROM stdin;
 --
 
 COPY public.resource (id, user_data_id, file_name, shared_status, category, type, creation_date, modification_date) FROM stdin;
-1	3	Extrait - La Boétie.pdf	public	recherche_de_sens	cours_pdf	2024-03-11 15:13:03	2024-03-11 15:13:03
+1	3	Extrait - La Boétie.pdf	public	recherche_de_sens	cours_pdf	2024-03-13 15:06:06	2024-03-13 15:06:06
 \.
 
 
@@ -276,7 +286,7 @@ COPY public.resource (id, user_data_id, file_name, shared_status, category, type
 --
 
 COPY public.resource_metadata (id, resource_id, title, duration, format, author, album, genre, release_date, creation_date, modification_date) FROM stdin;
-1	1	Discours de la servitude volontaire	\N	\N	Etienne de La Boétie	\N	\N	\N	2024-03-11 15:13:03	2024-03-11 15:13:03
+1	1	Discours de la servitude volontaire	\N	\N	Etienne de La Boétie	\N	\N	\N	2024-03-13 15:06:06	2024-03-13 15:06:06
 \.
 
 
@@ -293,10 +303,10 @@ COPY public.resource_relation_type (resource_id, relation_type_id) FROM stdin;
 -- Data for Name: user; Type: TABLE DATA; Schema: public; Owner: pedro
 --
 
-COPY public."user" (id, username, account_enabled) FROM stdin;
-1	Pedro	t
-2	Maria	t
-3	UserForDeleteTest	t
+COPY public."user" (id, username, account_enabled, role) FROM stdin;
+1	Pedro	t	citoyen connecté
+2	Maria	t	citoyen connecté
+3	UserForDeleteTest	t	citoyen connecté
 \.
 
 

--- a/migrations/Version20240313142256.php
+++ b/migrations/Version20240313142256.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240313142256 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD role VARCHAR(255) CHECK(role IN (\'citoyen connecté\', \'modérateur\', \'administrateur\', \'super administrateur\')) DEFAULT \'citoyen connecté\' NOT NULL');
+        $this->addSql('COMMENT ON COLUMN "user".role IS \'(DC2Type:userRoleType)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE "user" DROP role');
+    }
+}

--- a/src/Doctrine/DBAL/Types/UserRoleType.php
+++ b/src/Doctrine/DBAL/Types/UserRoleType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine\DBAL\Types;
+
+use App\Domain\Resource\UserRoleEnum;
+
+final class UserRoleType extends AbstractEnumType
+{
+    protected string $name = 'userRoleType';
+
+    protected function getValues(): array
+    {
+        return UserRoleEnum::values();
+    }
+}

--- a/src/Domain/Resource/UserRoleEnum.php
+++ b/src/Domain/Resource/UserRoleEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Resource;
+
+enum UserRoleEnum: string
+{
+    case USER_ROLE_CONNECTED_CITIZEN = 'citoyen connecté';
+    case USER_ROLE_MODERATOR = 'modérateur';
+    case USER_ROLE_CATALOG_ADMIN = 'administrateur';
+    case USER_ROLE_SUPER_ADMIN = 'super administrateur';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiProperty;
+use App\Domain\Resource\UserRoleEnum;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -31,6 +32,15 @@ class User
     #[ORM\OneToOne(mappedBy: 'user', targetEntity: UserData::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     #[Groups('read_user_with_user_details')]
     private ?UserData $userData = null;
+
+    #[ORM\Column(type: 'userRoleType', options: ['default' => UserRoleEnum::USER_ROLE_CONNECTED_CITIZEN->value])]
+    #[Groups(['read_user'])]
+    private string $role;
+
+    public function __construct()
+    {
+        $this->role = UserRoleEnum::USER_ROLE_CONNECTED_CITIZEN->value;
+    }
 
     public function getId(): int
     {
@@ -76,6 +86,18 @@ class User
     public function setUserData(UserData $userData): self
     {
         $this->userData = $userData;
+
+        return $this;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    public function setRole(string $role): self
+    {
+        $this->role = $role;
 
         return $this;
     }

--- a/tests/Integration/UserTest.php
+++ b/tests/Integration/UserTest.php
@@ -56,6 +56,7 @@ class UserTest extends ApiTestCase
             'id' => 2,
             'username' => 'Maria',
             'accountEnabled' => true,
+            'role' => 'citoyen connecté',
         ]);
     }
 


### PR DESCRIPTION
Ajout du champ "role" sur entité "User"
C'est un enum
Pour l'instant c'est purement cosmétique comme on n'a ni authent ni groupes de sécurité sur l'API
Un user est créé par défaut avec le rôle "citoyen connecté si pas de valeur précisée

Tests OK
Dumps SQL OK